### PR TITLE
Fix mods when elem as string given

### DIFF
--- a/lib/normalize2.js
+++ b/lib/normalize2.js
@@ -57,6 +57,9 @@ module.exports = function (decl) {
                     if (!isNotActual(mod)) {
                         processMods({ block, elem: elItem, mods: mod, tech });
                     }
+                    if (!isNotActual(mods)) {
+                        processMods({ block, elem: elItem, mods, tech });
+                    }
                 } else {
                     const elemNames = Array.isArray(elItem.elem) ? elItem.elem : [elItem.elem];
                     const modsExists = !isNotActual(elItem.mods);
@@ -76,11 +79,11 @@ module.exports = function (decl) {
             }
         }
 
-        if (!isNotActual(mod) && elems) {
+        if (!isNotActual(mod) && elems && !elem) {
             processMods({ block, mods: mod, tech });
         }
 
-        if (!isNotActual(mods)) {
+        if (!isNotActual(mods) && !elem) {
             processMods({ block, mods: mods, tech });
         }
 

--- a/test/normalize2/block-mods.test.js
+++ b/test/normalize2/block-mods.test.js
@@ -29,8 +29,8 @@ test('should pass mods to elem', t => {
 
     t.deepEqual(normalize(decl), [
         { entity: { block: 'block', elem: 'elem' }, tech: undefined },
-        { entity: { block: 'block', modName: 'm1', modVal: true }, tech: undefined },
-        { entity: { block: 'block', modName: 'm1', modVal: 'v1' }, tech: undefined }
+        { entity: { block: 'block', elem: 'elem', modName: 'm1', modVal: true }, tech: undefined },
+        { entity: { block: 'block', elem: 'elem', modName: 'm1', modVal: 'v1' }, tech: undefined }
     ]);
 });
 

--- a/test/normalize2/unusual.test.js
+++ b/test/normalize2/unusual.test.js
@@ -53,10 +53,8 @@ test('should support both mod, mods, elem and elems :\'(', t => {
         { entity: { block: 'block', elem: 'elem1' }, tech: undefined },
         { entity: { block: 'block', elem: 'elem1', modName: 'mod1', modVal: true }, tech: undefined },
         { entity: { block: 'block', elem: 'elem1', modName: 'mod1', modVal: 'v1' }, tech: undefined },
-        { entity: { block: 'block', modName: 'mod1', modVal: true }, tech: undefined },
-        { entity: { block: 'block', modName: 'mod1', modVal: 'v1' }, tech: undefined },
-        { entity: { block: 'block', modName: 'mod2', modVal: true }, tech: undefined },
-        { entity: { block: 'block', modName: 'mod2', modVal: 'v2' }, tech: undefined },
+        { entity: { block: 'block', elem: 'elem1', modName: 'mod2', modVal: true }, tech: undefined },
+        { entity: { block: 'block', elem: 'elem1', modName: 'mod2', modVal: 'v2' }, tech: undefined },
         { entity: { block: 'block', elem: 'elem2' }, tech: undefined }
     ]);
 });


### PR DESCRIPTION
```js
{
    block: 'block',
    elem: 'elem',
    mods: {
        m1: 'v1'
    }
 }
```
should normalized as
```js
[
    { entity: { block: 'block', elem: 'elem' }, tech: undefined },
    { entity: { block: 'block', elem: 'elem', modName: 'm1', modVal: true }, tech: undefined },
    { entity: { block: 'block', elem: 'elem', modName: 'm1', modVal: 'v1' }, tech: undefined }
]
```

instead of 
```js
[
    { entity: { block: 'block', elem: 'elem' }, tech: undefined },
    { entity: { block: 'block', modName: 'm1', modVal: true }, tech: undefined },
    { entity: { block: 'block', modName: 'm1', modVal: 'v1' }, tech: undefined }
]
```